### PR TITLE
Switching docs over to single-spa.js.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,4 @@ Generic lifecycle hooks for Cycle.js applications that are registered as [child 
 
 First, in the child application, run `npm install --save @pcmnac/single-spa-cycle`. Then, in your [child app's entry file](https://github.com/CanopyTax/single-spa/blob/docs-1/docs/configuring-child-applications.md#the-entry-file), do the following:
 
-```js
-
-import {run} from '@cycle/run'
-import {makeDOMDriver} from '@cycle/dom'
-import singleSpaCycle from '@pcmnac/single-spa-cycle';
-import rootComponent from './root.component.js';
-
-const cycleLifecycles = singleSpaCycle({
-	run,
-	rootComponent,
-	drivers: { DOM: makeDOMDriver(document.getElementById('main-content'))}, // or { DOM: makeDOMDriver('#main-content')}
-});
-
-export const bootstrap = [
-	cycleLifecycles.bootstrap
-];
-
-export const mount = [
-	cycleLifecycles.mount
-];
-
-export const unmount = [
-	cycleLifecycles.unmount
-];
-```
-
-## Options
-
-All options are passed to single-spa-cycle via the `opts` parameter when calling `singleSpaCycle(opts)`. The following options are available:
-
-- `run`: (required) Cycle.js run function.
-- `drivers`: (required) Drivers (including DOM Driver) to be used by your Cycle.js root component.
-- `rootComponent`: (required) The top level Cycle.js component which will be rendered
+[Full documentation](https://single-spa.js.org/docs/ecosystem-cycle.html)


### PR DESCRIPTION
We're moving all documentation into single-spa.js.org, for easier maintenance and use by the single-spa community.